### PR TITLE
ZNTA-2788 fix Maven plugin classloading issues with Java 11

### DIFF
--- a/client/zanata-cli/pom.xml
+++ b/client/zanata-cli/pom.xml
@@ -65,9 +65,8 @@
     </dependency>
 
     <dependency>
-    <groupId>org.glassfish.jaxb</groupId>
-    <artifactId>jaxb-runtime</artifactId>
-    <version>2.2.11</version>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
     </dependency>
 
     <!-- Replace the above JAXB dependencies when 2.4.0 is released: -->

--- a/client/zanata-maven-plugin/pom.xml
+++ b/client/zanata-maven-plugin/pom.xml
@@ -32,7 +32,7 @@
   <properties>
     <!-- Fedora 23 has 3.3.3 -->
     <maven.version>2.0.11</maven.version>
-    <maven.plugin.version>3.5</maven.plugin.version>
+    <maven.plugin.version>3.6.0</maven.plugin.version>
   </properties>
 
   <prerequisites>
@@ -127,6 +127,15 @@
     <dependency>
       <groupId>net.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
     </dependency>
   </dependencies>
 

--- a/client/zanata-maven-plugin/src/main/java/org/zanata/maven/ConfigurableMojo.java
+++ b/client/zanata-maven-plugin/src/main/java/org/zanata/maven/ConfigurableMojo.java
@@ -76,6 +76,14 @@ public abstract class ConfigurableMojo<O extends ConfigurableOptions> extends
     private boolean disableSSLCert = false;
 
     public ConfigurableMojo() {
+        // Hack for Java 11 class loading via modules - load all package-info classes here
+        try {
+            Class.forName("org.zanata.client.config.package-info");
+            Class.forName("org.zanata.rest.dto.package-info");
+            Class.forName("org.zanata.rest.dto.resource.package-info");
+        } catch (ClassNotFoundException e) {
+            // ignore class loading failure here
+        }
     }
 
     @Override

--- a/client/zanata-maven-plugin/src/main/java/org/zanata/maven/ConfigurableProjectMojo.java
+++ b/client/zanata-maven-plugin/src/main/java/org/zanata/maven/ConfigurableProjectMojo.java
@@ -106,8 +106,16 @@ public abstract class ConfigurableProjectMojo<O extends ConfigurableOptions>
         return project;
     }
 
+    public String getProject() {
+        return project;
+    }
+
     @Override
     public void setProj(String project) {
+        this.project = project;
+    }
+
+    public void setProject(String project) {
         this.project = project;
     }
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -212,13 +212,13 @@
     <restrict.skip>true</restrict.skip>
 
     <hamcrest.version>1.3</hamcrest.version>
-    <findbugs.maven.version>3.0.1</findbugs.maven.version>
+    <findbugs.maven.version>3.0.5</findbugs.maven.version>
     <!-- Note: Fedora 23 has 2.4.4. -->
     <groovy.version>2.4.4</groovy.version>
     <!-- Fedora 27 is still on 18.0: https://apps.fedoraproject.org/packages/guava -->
     <guava.version>18.0</guava.version>
     <jackson.version>1.9.13</jackson.version>
-    <jaxb.api.version>2.2.12</jaxb.api.version>
+    <jaxb.api.version>2.3.1</jaxb.api.version>
     <!-- Fedora <= 27 still uses maven-javadoc-plugin version 2.9.1 -->
     <maven.javadoc.version>3.0.0</maven.javadoc.version>
     <maven.jxr.version>2.5</maven.jxr.version>
@@ -1449,7 +1449,7 @@
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
-        <version>2.2.11</version>
+        <version>2.3.2</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/projects/ZNTA/issues/ZNTA-2788

Fixes zanata-maven-plugin for Java 11.

Java 11 changed the classloading to modules and Maven loads plugins as unnamed modules with "maven.api" as import. This prevents JAXB from loading the "package-info" classes with the @XmlSchema annotations. As a workaround I load the relevant classes in the org.zanata.maven.ConfigurableMojo.

Additionally I added a getter/setter for project in ConfigurableProjectMojo so that setting the project via Maven configuration works.